### PR TITLE
Support negative formatting precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,12 @@ It is possible to specify the precision with which to output numbers using the
 When `_prec` is set, results will be printed with `_prec` decimal places.
 By default, this variable is set to the value `5`.
 
-The number stored in `_prec` must be a natural number (i.e. positive integer).
-If a non-natural value is assigned, an error occurs and a message is printed.
+The number stored in `_prec` must be an integer.
+If a non-integer value is assigned, an error occurs and a message is printed.
+
+The positive value *N* will round to *N* places to the right of the decimal
+point. The negative value *-N* will round so that *N* places to the left of the
+decimal point contain zeros.
 
 ### Units
 

--- a/src/rat_util_macros.rs
+++ b/src/rat_util_macros.rs
@@ -19,22 +19,39 @@ along with Numbrs.  If not, see <https://www.gnu.org/licenses/>.
 
 */
 
+#![allow(unused_macros)]
+
 //! Helper macros for creating [BigRational][br] structs
 //!
 //! [br]: num_rational::BigRational
 
-/// Create a [BigRational]
+/// Create a [BigRational] from integer(s).
 ///
 /// Takes a numerator and a denominator argument. The denominator can be omitted
 /// to create a [BigRational] that represents an integer.
 macro_rules! rat {
     ( $a:expr ) => {
-        num::BigRational::from_integer(num::BigInt::from($a))
+        ::num::BigRational::from_integer(::num::BigInt::from($a))
     };
     ( $a:expr , $b:expr ) => {
-        num::BigRational::new(num::BigInt::from($a), num::BigInt::from($b))
+        ::num::BigRational::new(::num::BigInt::from($a), ::num::BigInt::from($b))
+    };
+}
+
+/// Create a [BigRational] from a floating-point value.
+///
+/// This is just a shortcut for [BigRational::from_f64()].
+///
+/// # Panics
+///
+/// This macro unwraps the [Result] returned by [BigRational::from_f64()], so it
+/// will panic if an [Err][Result::Err] variant is returned.
+macro_rules! ratf {
+    ( $f:expr ) => {
+        ::num::BigRational::from_float($f).unwrap()
     };
 }
 
 // Required to be able to import macros in other modules
-pub(crate) use rat;
+#[allow(unused_imports)]
+pub(crate) use {rat, ratf};

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -46,7 +46,7 @@ pub struct Runtime {
 }
 
 impl Runtime {
-    const DEFAULT_PRECISION: usize = 5;
+    const DEFAULT_PRECISION: isize = 5;
     const PRECISION_IDENT: &'static str = "_prec";
     pub const UNASSIGN_IDENT: &'static str = "_";
 
@@ -87,18 +87,12 @@ impl Runtime {
     pub fn format(&self, value: &Value) -> Result<String, RuntimeError> {
         match self.env.get(Self::PRECISION_IDENT) {
             Some(prec) => match prec {
-                Value::Number(rat) => {
-                    if rat.is_integer() {
-                        match rat.to_usize() {
-                            Some(precision) => Ok(value.format(precision)),
-                            None => Err(RuntimeError::InvalidPrecision(prec.clone())),
-                        }
-                    } else {
-                        Err(RuntimeError::InvalidPrecision(prec.clone()))
-                    }
-                }
+                Value::Number(rat) => match (rat.is_integer(), rat.to_isize()) {
+                    (true, Some(precision)) => Ok(value.format(precision)),
+                    _ => Err(RuntimeError::NonIntegerPrecision(prec.clone())),
+                },
                 Value::Quantity(_) | Value::Unit(_) => {
-                    Err(RuntimeError::InvalidPrecision(prec.clone()))
+                    Err(RuntimeError::NonIntegerPrecision(prec.clone()))
                 }
             },
             None => Ok(value.format(Self::DEFAULT_PRECISION)),
@@ -168,8 +162,8 @@ pub enum RuntimeError {
     #[error("Evaluation error: {0}")]
     Eval(#[from] EvalError),
 
-    #[error("Got non-natural precision specifier `{}`. Unable to format result.", .0.format(3))]
-    InvalidPrecision(Value),
+    #[error("Got non-integer precision specifier `{}`. Unable to format result.", .0.format(3))]
+    NonIntegerPrecision(Value),
 
     #[error("Can't assign special variable `{0}`")]
     AssignmentProhibited(String),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -177,40 +177,9 @@ pub enum RuntimeError {
 
 #[cfg(test)]
 mod tests {
-    use std::f64::consts::PI;
-
-    use pretty_assertions::assert_eq;
+    use ::pretty_assertions::assert_eq;
 
     use super::*;
-
-    #[test]
-    fn format() {
-        macro_rules! case {
-            ( $a:expr , $b:expr, $c:expr ) => {
-                (
-                    BigRational::from_float($a as f64).unwrap(),
-                    $b as f64,
-                    stringify!($c),
-                )
-            };
-        }
-
-        let mut rt = Runtime::new();
-        let cases = [
-            case!(13.14159, 2, 13.14),
-            case!(PI, 0, 3),
-            case!(123.456, -1, 120),
-            case!(123.456, 4, 123.4560),
-            case!(19, 2, 19.00),
-            case!(12.345, 1.5, 12.35),
-        ];
-
-        for (value, prec, expected) in cases {
-            // rt.env.insert("_prec".to_string(), prec);
-            rt.evaluate(&format!("_prec = {}", prec)).unwrap();
-            assert_eq!(expected, rt.format(&value.into()).unwrap());
-        }
-    }
 
     #[test]
     fn assign_protected() {


### PR DESCRIPTION
Negative precision behaves the same as positive precision, but to the left of the decimal point instead of to the right.
    
For example, 123.456 rounded to a precision of 2 is 123.46. 123.456 rounded to a precision of -2 is 100.