### PR TITLE
Code efficiency/readability changes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -43,7 +43,7 @@ fn compile_message(name: &str) -> Result<(), Box<dyn Error>> {
 
     // Create destination file and parent directory
     fs::create_dir_all(dest_dir)?; // create_dir_all() doesn't fail if dir exists
-    let mut outbuf = BufWriter::new(File::create(&out_file)?);
+    let mut outbuf = BufWriter::new(File::create(out_file)?);
 
     // Read message source
     let mut message = String::new();

--- a/src/affixes.rs
+++ b/src/affixes.rs
@@ -82,7 +82,7 @@ pub fn resolve_unit(name: &str, env: &HashMap<String, Value>) -> Option<Unit> {
 /// Attempt to look up a unit with prefix substitution.
 fn try_get_unit(name: &str, env: &HashMap<String, Value>) -> Option<Unit> {
     if let Some(Value::Unit(units)) = env.get(name) {
-        return Some(units.collapse_to(name.to_string()));
+        return Some(units.collapse_to(name));
     }
 
     // Search for existing unit by stripping available prefixes
@@ -94,7 +94,7 @@ fn try_get_unit(name: &str, env: &HashMap<String, Value>) -> Option<Unit> {
                 }
                 // If a unit definition is found, create a new Unit with the
                 // prefixed name and adjusted scale.
-                let mut new = units.collapse_to(name.to_string());
+                let mut new = units.collapse_to(name);
                 new.scale *= prefix.scale();
                 return Some(new);
             }

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -91,9 +91,10 @@ impl From<&[i32]> for Dimension {
     /// [1]: BaseQuantity
     fn from(src: &[i32]) -> Self {
         let mut new = Self::new();
-        for i in 0..min(src.len(), BaseQuantity::COUNT) {
-            new.0[i] = src[i];
-        }
+        let max = min(src.len(), BaseQuantity::COUNT);
+        let src = &src[0..max];
+        let dest = &mut new.0[0..max];
+        dest.copy_from_slice(src);
         new
     }
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -426,21 +426,16 @@ impl Node {
 ///
 /// Returns the [Value] of the RHS wrapped in a [Result], or an [EvalError] on
 /// failure.
-fn handle_assignment<T>(
-    name: T,
+fn handle_assignment(
+    name: &str,
     rhs: Node,
     unit: bool,
     env: &mut HashMap<String, Value>,
-) -> Result<Value, EvalError>
-where
-    T: ToString,
-{
-    let name = name.to_string();
-
+) -> Result<Value, EvalError> {
     // If RHS = Variable("_"), remove LHS from environment
     if let Node::Variable(rvar) = &rhs {
         if rvar.name() == Runtime::UNASSIGN_IDENT {
-            env.remove(&name);
+            env.remove(name);
             return Ok(BigRational::zero().into());
         }
     }
@@ -452,18 +447,18 @@ where
     if unit {
         rval = Value::from(Units::from([match rval {
             Value::Quantity(q) => Unit::new(
-                name.clone(),
+                name,
                 1,
                 q.mag * q.units.aggregate_scales(),
                 rat!(0),
                 q.units.dimension(),
             ),
-            Value::Unit(units) => units.collapse_to(name.clone()),
-            Value::Number(rat) => Unit::new(name.clone(), 1, rat, rat!(0), Dimension::new()),
+            Value::Unit(units) => units.collapse_to(name),
+            Value::Number(rat) => Unit::new(name, 1, rat, rat!(0), Dimension::new()),
         }]))
     }
 
-    env.insert(name, rval.clone());
+    env.insert(name.to_owned(), rval.clone());
     Ok(rval)
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -104,14 +104,10 @@ impl Runtime {
 fn create_base_units(env: &mut HashMap<String, Value>) {
     for variant in BaseQuantity::iter() {
         let name = variant.to_string();
-
         let mut dimension = Dimension::new();
         dimension[variant] = 1;
-
-        env.insert(
-            name.clone(),
-            Units::from(vec![Unit::new(name, 1, rat!(1), rat!(0), dimension)]).into(),
-        );
+        let units = Units::from(vec![Unit::new(&name, 1, rat!(1), rat!(0), dimension)]);
+        env.insert(name, units.into());
     }
 }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -89,10 +89,10 @@ impl Runtime {
             Some(prec) => match prec {
                 Value::Number(rat) => match (rat.is_integer(), rat.to_isize()) {
                     (true, Some(precision)) => Ok(value.format(precision)),
-                    _ => Err(RuntimeError::NonIntegerPrecision(prec.clone())),
+                    _ => Err(RuntimeError::NonIntegerPrecision(Box::new(prec.clone()))),
                 },
                 Value::Quantity(_) | Value::Unit(_) => {
-                    Err(RuntimeError::NonIntegerPrecision(prec.clone()))
+                    Err(RuntimeError::NonIntegerPrecision(Box::new(prec.clone())))
                 }
             },
             None => Ok(value.format(Self::DEFAULT_PRECISION)),
@@ -163,7 +163,7 @@ pub enum RuntimeError {
     Eval(#[from] EvalError),
 
     #[error("Got non-integer precision specifier `{}`. Unable to format result.", .0.format(3))]
-    NonIntegerPrecision(Value),
+    NonIntegerPrecision(Box<Value>),
 
     #[error("Can't assign special variable `{0}`")]
     AssignmentProhibited(String),

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -71,15 +71,15 @@ impl Unit {
     }
 
     /// Creates an new unit
-    pub fn new<T: ToString>(
-        name: T,
+    pub fn new(
+        name: &str,
         exponent: i32,
         scale: BigRational,
         offset: BigRational,
         dimension: Dimension,
     ) -> Self {
         Self {
-            name: name.to_string(),
+            name: name.to_owned(),
             exponent,
             scale,
             offset,
@@ -204,14 +204,8 @@ impl Units {
     }
 
     /// Create a new [Unit] identical to this [Units] list.
-    pub fn collapse_to(&self, name: String) -> Unit {
-        Unit::new(
-            name.clone(),
-            1,
-            self.aggregate_scales(),
-            rat!(0),
-            self.dimension(),
-        )
+    pub fn collapse_to(&self, name: &str) -> Unit {
+        Unit::new(name, 1, self.aggregate_scales(), rat!(0), self.dimension())
     }
 }
 
@@ -502,20 +496,8 @@ mod tests {
     /// Test conversion of pure quantities
     #[test]
     fn convert_pure() {
-        let a = Units::from([Unit::new(
-            "a".to_string(),
-            1,
-            rat!(5),
-            rat!(0),
-            Dimension::default(),
-        )]);
-        let b = Units::from([Unit::new(
-            "b".to_string(),
-            1,
-            rat!(3),
-            rat!(0),
-            Dimension::default(),
-        )]);
+        let a = Units::from([Unit::new("a", 1, rat!(5), rat!(0), Dimension::default())]);
+        let b = Units::from([Unit::new("b", 1, rat!(3), rat!(0), Dimension::default())]);
 
         let mut val = rat!(3);
         val = convert(&val, &a, &b).unwrap();

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -305,8 +305,8 @@ impl Display for Units {
 pub fn convert(n: &BigRational, from: &Units, to: &Units) -> Result<BigRational, EvalError> {
     if !from.conforms_to(to) {
         Err(EvalError::ConvertNonConformingUnits(
-            from.clone(),
-            to.clone(),
+            Box::new(from.clone()),
+            Box::new(to.clone()),
         ))
     } else {
         Ok(to.descale(&from.scale(n)))
@@ -324,7 +324,10 @@ impl Quantity {
             self.units = units;
             Ok(self)
         } else {
-            Err(EvalError::ConvertNonConformingUnits(self.units, units))
+            Err(EvalError::ConvertNonConformingUnits(
+                Box::new(self.units),
+                Box::new(units),
+            ))
         }
     }
 }


### PR DESCRIPTION
This PR does three main things which improve the efficiency and/or style of the codebase:
 * Use `copy_from_slice()` instead of looping
 * Use `&str` in function params instead of `ToString`
 * Reduce size of `EvalError` and `RuntimeError`

Each change is documented in the respective commit.