### PR TITLE
More strict code linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Cache build artifacts
         uses: Swatinem/rust-cache@v2
 
+      - name: Lint code
+        run: cargo clippy --all-targets --all-features
+
       - name: Compile tests
         run: cargo test --workspace --all-features --no-fail-fast --no-run --locked
 

--- a/src/affixes.rs
+++ b/src/affixes.rs
@@ -64,12 +64,11 @@ pub fn resolve_unit(name: &str, env: &HashMap<String, Value>) -> Option<Unit> {
         return Some(unit);
     }
 
-    for suffix in (*SUFFIX_MAP).keys() {
-        let sub: &str = (*SUFFIX_MAP).get(suffix).unwrap();
-        if let Some(part) = name.strip_suffix(suffix) {
+    for (suffix, substitution) in SUFFIX_MAP.iter() {
+        if let Some(base) = name.strip_suffix(suffix) {
             let mut new_name = String::with_capacity(name.len());
-            new_name.push_str(part);
-            new_name.push_str(sub);
+            new_name.push_str(base);
+            new_name.push_str(substitution);
             if let Some(unit) = try_get_unit(&new_name, env) {
                 return Some(unit);
             }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -487,6 +487,7 @@ pub enum EvalError {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use num::Zero;
     use pretty_assertions::assert_eq;

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -125,7 +125,7 @@ impl Iterator for Lexer {
                     self.chars.next(); // consume ':'
                     if let Some('=') = self.chars.peek() {
                         self.chars.next(); // consume '='
-                        Some(Token::Operator(Operation::from_str(":=").unwrap()))
+                        Some(Token::Operator(Operation::AssignUnit))
                     } else {
                         Some(Token::Illegal(c))
                     }
@@ -162,7 +162,9 @@ where
     let mut res = String::new();
     while let Some(&c) = chars.peek() {
         if predicate(c) {
-            // use chars.next() to advance the iterator
+            // Use chars.next() to advance the iterator. It's safe to unwrap
+            // because we already peeked the item so it must exist.
+            #[allow(clippy::unwrap_used)]
             res.push(chars.next().unwrap());
         } else {
             break;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,12 @@ along with Numbrs.  If not, see <https://www.gnu.org/licenses/>.
 
 */
 
+// Don't allow unwrapping Results and Options
+#![deny(clippy::unwrap_used)]
+
+// Make compiler warnings fatal
+#![deny(warnings)]
+
 extern crate num;
 extern crate strum;
 extern crate strum_macros;

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -140,7 +140,8 @@ mod tests {
         };
 
         assert_eq!(
-            Operation::unary_try_from("~=").unwrap_err(),
+            Operation::unary_try_from("~=")
+                .expect_err("Creating Operation from invalid operator succeeded"),
             OperationError::InvalidOperatorString(String::from("~="))
         )
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -190,6 +190,7 @@ pub enum ParseError {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use std::str::FromStr;
 

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -248,6 +248,9 @@ impl DivAssign for Units {
     fn div_assign(&mut self, rhs: Self) {
         for mut unit in rhs.0 {
             if self.0.contains(&unit) {
+                // We are sure the element exists because self.0.contains(...)
+                // is true, so we can unwrap.
+                #[allow(clippy::unwrap_used)]
                 self.0
                     .remove(self.0.iter().position(|x| *x == unit).unwrap());
             } else if let Some(idx) = self
@@ -327,6 +330,7 @@ impl Quantity {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use pretty_assertions::assert_eq;
 


### PR DESCRIPTION
This PR enables linting as a part of the CI pipeline.

It also makes the `.unrwap()` function illegal. To use it, one must allow its usage with an attribute and explain why it's acceptable.

Warnings are also made fatal. Any compiler or linter warnings are treated as errors and fail the build process.