### PR TITLE
Public API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,12 +194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,14 +322,20 @@ version = "1.2.1"
 dependencies = [
  "cargo_metadata",
  "glob",
- "lazy_static",
  "num",
+ "once_cell",
  "pretty_assertions",
  "rustyline",
  "strum",
  "strum_macros",
  "thiserror",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "output_vt100"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "Numbrs"
-version = "1.2.1"
-dependencies = [
- "cargo_metadata",
- "glob",
- "lazy_static",
- "num",
- "pretty_assertions",
- "rustyline",
- "strum",
- "strum_macros",
- "thiserror",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -335,6 +320,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "numbrs"
+version = "1.2.1"
+dependencies = [
+ "cargo_metadata",
+ "glob",
+ "lazy_static",
+ "num",
+ "pretty_assertions",
+ "rustyline",
+ "strum",
+ "strum_macros",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,8 @@ name = "numbrs"
 path = "src/main.rs"
 
 [dependencies]
-lazy_static = "1.4.0"
 num = "0.4.0"
+once_cell = "1.17.0"
 rustyline = "10.0.0"
 strum = "0.24.1"
 strum_macros = "0.24.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@
 ##
 
 [package]
-name = "Numbrs"
+name = "numbrs"
 description = "A text-based calculator written in Rust"
 version = "1.2.1"
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,3 @@
-extern crate cargo_metadata;
-extern crate glob;
-
 use std::{
     env,
     error::Error,

--- a/build.rs
+++ b/build.rs
@@ -50,9 +50,15 @@ fn compile_message(name: &str) -> Result<(), Box<dyn Error>> {
 
     // Perform simple substitutions
     replace_with_env! { message;
-        "PROGNAME" -> "CARGO_PKG_NAME",
         "VERSION" -> "CARGO_PKG_VERSION",
     };
+
+    // Perform program name substitution
+    let progname = env::var("CARGO_PKG_NAME")?;
+    let mut chars = progname.chars();
+    let progname: String =
+        chars.next().unwrap().to_uppercase().collect::<String>() + chars.as_str();
+    message = message.replace("%PROGNAME%", &progname);
 
     // Perform author substitution
     let authors: String = env::var("CARGO_PKG_AUTHORS")?;

--- a/src/affixes.rs
+++ b/src/affixes.rs
@@ -21,8 +21,8 @@ along with Numbrs.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
 
-use lazy_static::lazy_static;
 use num::BigRational;
+use once_cell::sync::Lazy;
 
 use crate::{ast::Value, rat_util_macros::rat, unit::Unit};
 
@@ -53,7 +53,17 @@ impl Prefix {
         &self.scale
     }
 
-    /// Get the prefix's standalone status.
+    /// Whether or not the [`Prefix`] also acts as a standalone variable
+    /// representing its scale as a numeric value.
+    ///
+    /// For example, the prefix `kilo` is standalone, but `k` is not:
+    /// ```txt
+    /// $ numbrs
+    /// > kilo
+    /// 1000
+    /// > k
+    /// Error: Evaluation error: `k` not defined
+    /// ```
     pub fn standalone(&self) -> bool {
         self.standalone
     }
@@ -65,7 +75,8 @@ pub fn resolve_unit(name: &str, env: &HashMap<String, Value>) -> Option<Unit> {
         return Some(unit);
     }
 
-    for (suffix, substitution) in SUFFIX_MAP.iter() {
+    // TODO: don't transform units which don't support suffixes, e.g. `kg`
+    for (suffix, substitution) in standard_suffixes() {
         if let Some(base) = name.strip_suffix(suffix) {
             let mut new_name = String::with_capacity(name.len());
             new_name.push_str(base);
@@ -86,7 +97,7 @@ fn try_get_unit(name: &str, env: &HashMap<String, Value>) -> Option<Unit> {
     }
 
     // Search for existing unit by stripping available prefixes
-    for prefix in (*PREFIXES).iter() {
+    for prefix in standard_prefixes() {
         if let Some(s) = name.strip_prefix(prefix.text()) {
             if let Some(Value::Unit(units)) = env.get(s) {
                 if (*units).len() > 1 || (*units)[0].offset != rat!(0) {
@@ -107,7 +118,7 @@ fn try_get_unit(name: &str, env: &HashMap<String, Value>) -> Option<Unit> {
 /// Attempt to get the scale value of a [Prefix].
 pub fn try_get_prefix_scale(name: &str) -> Option<BigRational> {
     Some(
-        (*PREFIXES)
+        standard_prefixes()
             .iter()
             .find(|prefix| prefix.standalone() && prefix.text() == name)?
             .scale()
@@ -117,7 +128,7 @@ pub fn try_get_prefix_scale(name: &str) -> Option<BigRational> {
 
 macro_rules! prefixes {
     ( $( $name:literal $base:literal^$scale:literal $standalone:tt ),* $(,)? ) => {
-        vec![ $(
+        [ $(
             Prefix::new(
                 $name,
                 rat!($base).pow($scale),
@@ -127,85 +138,97 @@ macro_rules! prefixes {
     };
 }
 
-lazy_static! {
-    /// Standard prefixes for units.
-    /// Mostly derived from <https://frinklang.org/frinkdata/units.txt>.
-    pub static ref PREFIXES: Vec<Prefix> = prefixes![
-        "yotta"  10^24  y,
-        "zetta"  10^21  y,
-        "exa"    10^18  y,
-        "peta"   10^15  y,
-        "tera"   10^12  y,
-        "giga"    10^9  y,
-        "mega"    10^6  y,
-        "myria"   10^4  y,
-        "kilo"    10^3  y,
-        "hecto"   10^2  y,
-        "deca"    10^1  y,
-        "deka"    10^1  y,
-        "deci"   10^-1  y,
-        "centi"  10^-2  y,
-        "milli"  10^-3  y,
-        "micro"  10^-6  y,
-        "nano"   10^-9  y,
-        "pico"  10^-12  y,
-        "femto" 10^-15  y,
-        "atto"  10^-18  y,
-        "zepto" 10^-21  y,
-        "yocto" 10^-24  y,
+/// # Standard prefixes for units.
+/// 
+/// This function returns a static slice of [`Prefix`] items which makes up the
+/// list of standard unit prefixes.
+///
+/// Contains both [SI][1] and [IEC][2] prefixes.
+/// Mostly derived from <https://frinklang.org/frinkdata/units.txt>.
+///
+/// [1]: https://en.wikipedia.org/wiki/International_System_of_Units#Prefixes
+/// [2]: https://en.wikipedia.org/wiki/Byte#Units_based_on_powers_of_2
+pub fn standard_prefixes() -> &'static [Prefix] {
+    static PREFIXES: Lazy<[Prefix; 59]> = Lazy::new(|| {
+        prefixes![
+            "yotta"  10^24  y,
+            "zetta"  10^21  y,
+            "exa"    10^18  y,
+            "peta"   10^15  y,
+            "tera"   10^12  y,
+            "giga"    10^9  y,
+            "mega"    10^6  y,
+            "myria"   10^4  y,
+            "kilo"    10^3  y,
+            "hecto"   10^2  y,
+            "deca"    10^1  y,
+            "deka"    10^1  y,
+            "deci"   10^-1  y,
+            "centi"  10^-2  y,
+            "milli"  10^-3  y,
+            "micro"  10^-6  y,
+            "nano"   10^-9  y,
+            "pico"  10^-12  y,
+            "femto" 10^-15  y,
+            "atto"  10^-18  y,
+            "zepto" 10^-21  y,
+            "yocto" 10^-24  y,
 
-        "Y"  10^24   n, // yotta
-        "Z"  10^21   n, // zetta
-        "E"  10^18   n, // exa
-        "P"  10^15   n, // peta
-        "T"  10^12   n, // tera
-        "G"   10^9   n, // giga
-        "M"   10^6   n, // mega
-        "k"   10^3   n, // kilo
-        "h"   10^2   n, // hecto
-        "da"  10^1   n, // deka
-        "d"  10^-1   n, // deci
-        "c"  10^-2   n, // centi
-        "m"  10^-3   n, // milli
-        "µ"  10^-6   n, // micro
-        "u"  10^-6   n, // micro (ASCII alternative)
-        "n"  10^-9   n, // nano
-        "p"  10^-12  n, // pico
-        "f"  10^-15  n, // femto
-        "a"  10^-18  n, // atto
-        "z"  10^-21  n, // zepto
-        "y"  10^-24  n, // yocto
+            "Y"  10^24   n, // yotta
+            "Z"  10^21   n, // zetta
+            "E"  10^18   n, // exa
+            "P"  10^15   n, // peta
+            "T"  10^12   n, // tera
+            "G"   10^9   n, // giga
+            "M"   10^6   n, // mega
+            "k"   10^3   n, // kilo
+            "h"   10^2   n, // hecto
+            "da"  10^1   n, // deka
+            "d"  10^-1   n, // deci
+            "c"  10^-2   n, // centi
+            "m"  10^-3   n, // milli
+            "µ"  10^-6   n, // micro
+            "u"  10^-6   n, // micro (ASCII alternative)
+            "n"  10^-9   n, // nano
+            "p"  10^-12  n, // pico
+            "f"  10^-15  n, // femto
+            "a"  10^-18  n, // atto
+            "z"  10^-21  n, // zepto
+            "y"  10^-24  n, // yocto
 
-        "kibi"  1024^1  y,
-        "mebi"  1024^2  y,
-        "gibi"  1024^3  y,
-        "tebi"  1024^4  y,
-        "pebi"  1024^5  y,
-        "exbi"  1024^6  y,
-        "zebi"  1024^7  y,
-        "yobi"  1024^8  y,
+            "kibi"  1024^1  y,
+            "mebi"  1024^2  y,
+            "gibi"  1024^3  y,
+            "tebi"  1024^4  y,
+            "pebi"  1024^5  y,
+            "exbi"  1024^6  y,
+            "zebi"  1024^7  y,
+            "yobi"  1024^8  y,
 
-        "Ki"  1024^1  n, // kibi
-        "Mi"  1024^2  n, // mebi
-        "Gi"  1024^3  n, // gibi
-        "Ti"  1024^4  n, // tebi
-        "Pi"  1024^5  n, // pebi
-        "Ei"  1024^6  n, // exbi
-        "Zi"  1024^7  n, // zebi
-        "Yi"  1024^8  n, // yobi
-    ];
+            "Ki"  1024^1  n, // kibi
+            "Mi"  1024^2  n, // mebi
+            "Gi"  1024^3  n, // gibi
+            "Ti"  1024^4  n, // tebi
+            "Pi"  1024^5  n, // pebi
+            "Ei"  1024^6  n, // exbi
+            "Zi"  1024^7  n, // zebi
+            "Yi"  1024^8  n, // yobi
+        ]
+    });
+    &*PREFIXES
+}
 
-    /// List of suffixes which map to singular suffix translation.
-    ///
-    /// For example, "henries" is the plural of "henry" so the suffix "ies" maps to "y".
-    /// "bytes" is the plural of "byte", so the suffix "s" maps to nothing ("").
-    pub static ref SUFFIX_MAP: HashMap<String, String> = {
-        let mut map = HashMap::new();
-        map.insert("s".to_string(), "".to_string());
-        map.insert("es".to_string(), "".to_string());
-        map.insert("ies".to_string(), "y".to_string());
-        map
-    };
+/// # Standard suffixes for units
+/// 
+/// This function returns a static slice of string pairs.
+/// 
+/// Each pair contains a plural suffix and its equivalent singular form.
+///
+/// For example, `henries` is the plural of `henry` so the suffix `ies` maps to
+/// `y`. `bytes` is the plural of `byte`, where the suffix `s` maps to nothing
+/// (i.e. an empty string).
+pub fn standard_suffixes() -> &'static [(&'static str, &'static str)] {
+    &[("s", ""), ("es", ""), ("ies", "y")]
 }
 
 #[cfg(test)]
@@ -215,7 +238,7 @@ mod tests {
     /// Just test the first two prefixes to make sure the assignment works.
     #[test]
     fn std_prefixes() {
-        assert!(PREFIXES.contains(&Prefix::new("yotta", rat!(10).pow(24), true)));
-        assert!(PREFIXES.contains(&Prefix::new("k", rat!(1000), false)));
+        assert!(standard_prefixes().contains(&Prefix::new("yotta", rat!(10).pow(24), true)));
+        assert!(standard_prefixes().contains(&Prefix::new("k", rat!(1000), false)));
     }
 }

--- a/src/affixes.rs
+++ b/src/affixes.rs
@@ -35,9 +35,9 @@ pub struct Prefix {
 
 impl Prefix {
     /// Create a new prefix.
-    pub fn new<T: ToString>(text: T, scale: BigRational, standalone: bool) -> Self {
+    pub fn new(text: &str, scale: BigRational, standalone: bool) -> Self {
         Self {
-            text: text.to_string(),
+            text: text.to_owned(),
             scale,
             standalone,
         }

--- a/src/affixes.rs
+++ b/src/affixes.rs
@@ -21,6 +21,7 @@ along with Numbrs.  If not, see <https://www.gnu.org/licenses/>.
 
 use std::collections::HashMap;
 
+use lazy_static::lazy_static;
 use num::BigRational;
 
 use crate::{ast::Value, rat_util_macros::rat, unit::Unit};

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -36,7 +36,7 @@ use strum_macros::{Display, EnumCount as EnumCountMacro, EnumIter, EnumVariantNa
 /// Each variant represents a [basic physical dimension/quantity][1].
 ///
 /// [1]: https://en.wikipedia.org/wiki/Physical_quantity#Dimensions
-#[derive(Clone, Copy, PartialEq, Eq, EnumCountMacro, EnumIter, EnumVariantNames, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EnumCountMacro, EnumIter, EnumVariantNames, Display)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub(crate) enum BaseQuantity {
     Length,

--- a/src/dimension.rs
+++ b/src/dimension.rs
@@ -38,7 +38,7 @@ use strum_macros::{Display, EnumCount as EnumCountMacro, EnumIter, EnumVariantNa
 /// [1]: https://en.wikipedia.org/wiki/Physical_quantity#Dimensions
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumCountMacro, EnumIter, EnumVariantNames, Display)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
-pub(crate) enum BaseQuantity {
+pub enum BaseQuantity {
     Length,
     Mass,
     Time,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -36,7 +36,7 @@ use crate::{
     unit::{self, Unit, Units},
 };
 
-trait Operable {
+pub trait Operable {
     fn binary_op(self, op: Operation, rhs: Value) -> Result<Value, EvalError>;
     fn unary_op(self, op: Operation) -> Result<Value, EvalError>;
 }
@@ -319,7 +319,7 @@ impl Operable for Units {
 }
 
 impl Variable {
-    fn eval(self, env: &HashMap<String, Value>) -> Result<Value, EvalError> {
+    pub fn eval(self, env: &HashMap<String, Value>) -> Result<Value, EvalError> {
         match env.get(self.name()) {
             Some(val) => Ok(val.clone()),
             None => match resolve_unit(self.name(), env) {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -353,7 +353,6 @@ impl Node {
     /// # Examples
     ///
     /// ```
-    /// # extern crate num;
     /// # use num::{BigInt, BigRational};
     /// # use numbrs::{
     /// #     ast::{BinaryExpression, Node, Value},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,16 +22,6 @@ along with Numbrs.  If not, see <https://www.gnu.org/licenses/>.
 // Don't allow unwrapping Results and Options
 #![deny(clippy::unwrap_used)]
 
-extern crate num;
-extern crate strum;
-extern crate strum_macros;
-extern crate thiserror;
-#[macro_use]
-extern crate lazy_static;
-
-#[cfg(test)]
-extern crate pretty_assertions;
-
 pub mod affixes;
 pub mod ast;
 pub mod dimension;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,6 @@ along with Numbrs.  If not, see <https://www.gnu.org/licenses/>.
 
 */
 
-extern crate rustyline;
-
 use numbrs::runtime::Runtime;
 use rustyline::{error::ReadlineError, Editor};
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -19,40 +19,48 @@ along with Numbrs.  If not, see <https://www.gnu.org/licenses/>.
 
 */
 
-// Disable warning about unary operator patterns being unreachable
-#![allow(unreachable_patterns)]
-
-use strum_macros::{Display, EnumString};
 use thiserror::Error;
 
-#[derive(Copy, Clone, Debug, EnumString, Display, PartialEq, Eq)]
-pub enum Operation {
-    #[strum(serialize = "+")]
-    Add,
-    #[strum(serialize = "-")]
-    Subtract,
+// We put Operation in its own module because the strum macros cause warnings
+// which cannot be disabled for just the Operation type since they occur within
+// the procedural macros. We have to allow the unreachable_patterns diagnostic
+// for the containing module, so we isolate it into its own module.
+mod inner {
+    // Disable warning about unary operator patterns being unreachable
+    #![allow(unreachable_patterns)]
 
-    #[strum(serialize = "*")]
-    Multiply,
-    #[strum(serialize = "/")]
-    Divide,
+    use strum_macros::{Display, EnumString};
 
-    #[strum(serialize = "^")]
-    Raise,
+    #[derive(Copy, Clone, Debug, EnumString, Display, PartialEq, Eq)]
+    pub enum Operation {
+        #[strum(serialize = "+")]
+        Add,
+        #[strum(serialize = "-")]
+        Subtract,
 
-    #[strum(serialize = "=")]
-    Assign,
-    #[strum(serialize = ":=")]
-    AssignUnit,
+        #[strum(serialize = "*")]
+        Multiply,
+        #[strum(serialize = "/")]
+        Divide,
 
-    #[strum(serialize = "+")]
-    UnaryAdd,
-    #[strum(serialize = "-")]
-    UnarySubtract,
+        #[strum(serialize = "^")]
+        Raise,
 
-    #[strum(serialize = "to")]
-    ConvertUnits,
+        #[strum(serialize = "=")]
+        Assign,
+        #[strum(serialize = ":=")]
+        AssignUnit,
+
+        #[strum(serialize = "+")]
+        UnaryAdd,
+        #[strum(serialize = "-")]
+        UnarySubtract,
+
+        #[strum(serialize = "to")]
+        ConvertUnits,
+    }
 }
+pub use inner::Operation;
 
 impl Operation {
     pub fn unary_try_from(opstr: &str) -> Result<Self, OperationError> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -34,17 +34,36 @@ use crate::{
 };
 
 #[derive(Debug)]
-pub struct Parser {
-    tokens: Peekable<Lexer>,
+pub struct Parser<I>
+where
+    I: Iterator<Item = Token>,
+{
+    tokens: Peekable<I>,
 }
 
-impl Parser {
-    pub fn new(src: &str) -> Self {
+impl<'a> Parser<Lexer<'a>> {
+    /// Create a new [`Parser`] from a string slice.
+    ///
+    /// Under the hood, this creates a new [`Lexer`] for the string and then
+    /// calls [`Parser::from()`] on that.
+    pub fn new(src: &'a str) -> Self {
+        Self::from(Lexer::new(src))
+    }
+}
+
+impl<'a> From<Lexer<'a>> for Parser<Lexer<'a>> {
+    /// Create a new [`Parser`] from a [`Lexer`].
+    fn from(lexer: Lexer<'a>) -> Self {
         Self {
-            tokens: Lexer::new(src).peekable(),
+            tokens: lexer.peekable(),
         }
     }
+}
 
+impl<I> Parser<I>
+where
+    I: Iterator<Item = Token>,
+{
     /// Parse the input token stream into a tree of [Nodes][Node].
     pub fn parse(mut self) -> Result<Node, ParseError> {
         self.parse_expr(0)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -33,6 +33,7 @@ use crate::{
     operation::Operation,
 };
 
+#[derive(Debug)]
 pub struct Parser {
     tokens: Peekable<Lexer>,
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -41,6 +41,7 @@ use crate::{
 ///
 /// Handles storage of variable map and application of user
 /// preferences like output format precision.
+#[derive(Debug)]
 pub struct Runtime {
     env: HashMap<String, Value>,
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -47,8 +47,8 @@ pub struct Runtime {
 }
 
 impl Runtime {
-    const DEFAULT_PRECISION: isize = 5;
-    const PRECISION_IDENT: &'static str = "_prec";
+    pub const DEFAULT_PRECISION: isize = 5;
+    pub const PRECISION_IDENT: &'static str = "_prec";
     pub const UNASSIGN_IDENT: &'static str = "_";
 
     pub fn new() -> Self {

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -55,11 +55,11 @@ use crate::{ast::Quantity, dimension::Dimension, eval::EvalError, rat_util_macro
 /// [1]: crate::unit
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct Unit {
-    pub(crate) name: String,
-    pub(crate) exponent: i32,
-    pub(crate) scale: BigRational,
-    pub(crate) offset: BigRational,
-    pub(crate) dimension: Dimension,
+    pub name: String,
+    pub exponent: i32,
+    pub scale: BigRational,
+    pub offset: BigRational,
+    pub dimension: Dimension,
 }
 
 impl Unit {
@@ -85,11 +85,6 @@ impl Unit {
             offset,
             dimension,
         }
-    }
-
-    /// Get the dimension of a unit
-    pub fn dimension(&self) -> Dimension {
-        self.dimension
     }
 }
 
@@ -128,7 +123,7 @@ impl Units {
     ///
     /// Raises each unit's dimension to its exponent, then multiplies the
     /// results together.
-    pub(crate) fn dimension(&self) -> Dimension {
+    pub fn dimension(&self) -> Dimension {
         self.0
             .iter()
             .map(|unit| unit.dimension.pow(unit.exponent))


### PR DESCRIPTION
The PR makes the following changes. Each change is justified and explained in its respective commit.

- Make fields of `Unit` public
- Make runtime identifier constants public
- Isolate `Operation` into its own sub-module
- Delete `parser::BindingPower` trait
- Change implementation of `Lexer` and `Parser`
- Make several evaluation functions public
- Wrap prefix and suffix lists in accessor functions
- Use `&str` in function params instead of `ToString`
- Make `BaseQuantity` type public
- Derive missing `Debug` implementations
- Change package name to lowercase
- Remove `extern crate` declarations