### PR TITLE
Enable additional compiler warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,16 @@ along with Numbrs.  If not, see <https://www.gnu.org/licenses/>.
 
 // Don't allow unwrapping Results and Options
 #![deny(clippy::unwrap_used)]
+// Warn about additional compiler diagnostics. These don't affect the behavior
+// or performance of Numbrs, but they generally lead to cleaner code.
+#![warn(
+    missing_docs,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    unreachable_pub,
+    unused_extern_crates,
+    macro_use_extern_crate
+)]
 
 //! # Numbrs
 //!


### PR DESCRIPTION
This commit makes the Rust compiler warn about several additional diagnostics. None of these should impact Numbrs' performance or features, but they should encourage better/cleaner code.

The most important new diagnostic is `warn(missing_docs)` which will produce a warning (and this fail the build) if a public member is missing documentation.